### PR TITLE
Fix guzzlehttp/guzzle to only allow v7.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ This SDK initially require [UBL-Invoice](https://github.com/num-num/ubl-invoice)
 - [x] Get Document Details
 - [x] Search Documents
 - [x] Digital Signature
-- [ ] Mandatory Field Verification
 - [x] Get Document's QR Code URL
 
 ## Installation and usage

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,8 @@
         "myinvois",
         "lhdn",
         "irbm",
-        "malaysia"
+        "malaysia",
+        "einvoicing"
     ],
     "homepage": "https://github.com/klsheng/myinvois-php-sdk",
     "license": "MIT",
@@ -19,7 +20,7 @@
     ],
     "require": {
         "php": ">=7.4",
-        "guzzlehttp/guzzle": "~7.0|~6.0|~5.0|~4.0",
+        "guzzlehttp/guzzle": "~7.0",
         "ext-curl": "*",
         "ext-json": "*",
         "ext-openssl": "*",


### PR DESCRIPTION
guzzlehttp/guzzle below v7 (E.g: v6.x) does not have Psr\Http\Client\ClientInterface, so from now we will only support v7.x and above.