### PR TITLE
Fix: Improve UTF-8 encoding handling for multibyte characters (e.g., Chinese)

### DIFF
--- a/src/Ubl/Builder/JsonDocumentBuilder.php
+++ b/src/Ubl/Builder/JsonDocumentBuilder.php
@@ -40,7 +40,9 @@ class JsonDocumentBuilder extends AbstractDocumentBuilder
 
         // $content = json_encode(json_decode($content), JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
         $content = str_replace(array("\r", "\n"), '', $content);
-        $content = utf8_encode($content);
+        if (!mb_check_encoding($content, 'UTF-8')) {
+						$content = mb_convert_encoding($content, 'UTF-8', 'auto');
+				}
 
         // XML and JSON has different value for this
         if($this->isSigned) {
@@ -65,7 +67,9 @@ class JsonDocumentBuilder extends AbstractDocumentBuilder
             $signature->getObject()->getQualifyingProperties(), 
             JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
 
-        $content = utf8_encode($content);
+        if (!mb_check_encoding($content, 'UTF-8')) {
+						$content = mb_convert_encoding($content, 'UTF-8', 'auto');
+				}
 
         return MyInvoisHelper::getHash($content, true);
     }


### PR DESCRIPTION
## Fix: Improve UTF-8 encoding handling for multibyte characters (e.g., Chinese)

### Summary

This pull request enhances UTF-8 encoding support across the document signing flow to correctly handle multibyte characters such as Chinese.

### Changes

- Replaced usage of `utf8_encode()` with `mb_convert_encoding()` for safer and more accurate UTF-8 conversion.
- Ensured JSON strings used in signing and hashing are properly validated and encoded as UTF-8.
- Added `mb_check_encoding()` to detect and correct invalid encodings before processing.

### Motivation

The previous use of `utf8_encode()` incorrectly assumed ISO-8859-1 input, which can corrupt multibyte characters like `螺丝`. 